### PR TITLE
Makes Parts (TFD data type) a tuple (plus housekeeping)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssb-uri-rs"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Andrew Reid <glyph@mycelial.technology>"]
 description = "Utilities for recognising and converting Secure Scuttlebutt (SSB) URIs"
 edition = "2018"

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Utilities for recognising and converting Secure Scuttlebutt (SSB) URIs according to the [SSB URI Specification](https://github.com/ssb-ngi-pointer/ssb-uri-spec).
 
+[![ssb-uri-rs crate](https://img.shields.io/crates/v/ssb-uri-rs)](https://crates.io/crates/ssb-uri-rs)
+
 ## Example
 
 ```rust


### PR DESCRIPTION
I realised when using this library in `ssb-bfe-rs` that the `Parts` `struct` is better implemented as a tuple `struct`.

We sacrifice named indexing but gain cleaner destructuring (which I think offers a more ergonomic and readable experience for library users).

I have also bumped the repo version and added a `crates.io` version badge with a link to the crate.

```rust
/* PREVIOUSLY */

let parts = decompose_uri(&uri)?;
// index by name (field)
match parts.format.as_str() {
    // "bendybutt-v1" => { ... }
}

/* CURRENTLY */

let parts = decompose_uri(&uri)?;
// index by number (position)
match parts.1.as_str() {
    // "classic" => { ... }
}

// or destructure instead
let (type_, format, data) = decompose_uri(&uri)?;
match format.as_str() {
    // "gabbygrove-v1" => { ... }
}


```