### PR TITLE
Make Parts tuple fields public

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssb-uri-rs"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Andrew Reid <glyph@mycelial.technology>"]
 description = "Utilities for recognising and converting Secure Scuttlebutt (SSB) URIs"
 edition = "2018"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,7 +63,7 @@ const FEED_FORMATS: [&str; 3] = ["ed25519", "bendybutt-v1", "gabbygrove-v1"];
 const MSG_FORMATS: [&str; 3] = ["sha256", "bendybutt-v1", "gabbygrove-v1"];
 
 /// Data representation for a TFD (`type`, `format`, `data`) identity.
-pub struct Parts(String, String, String);
+pub struct Parts(pub String, pub String, pub String);
 
 /// Check whether the `type` and `format` of the given `Parts` `struct` represent a canonical
 /// pairing.


### PR DESCRIPTION
Fixes a silly error which I overlooked. Tuple fields must be public to allow destructuring when using the library.