### PR TITLE
Remove query string error when testing multiserver address URI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssb-uri-rs"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Andrew Reid <glyph@mycelial.technology>"]
 description = "Utilities for recognising and converting Secure Scuttlebutt (SSB) URIs"
 edition = "2018"


### PR DESCRIPTION
The `is_multiserver_uri(uri)` function previously returned an `Err()` type when the query component of the given URI was empty. I realised while invoking this function in `ssb-bfe-rs` that we rather want to return `Ok(false)` in this case, since we are primarily concerned with the boolean outcome of the assessment.