### PR TITLE
Replace anyhow with custom error type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "ssb-uri-rs"
-version = "0.1.4"
+version = "0.2.0"
 authors = ["Andrew Reid <glyph@mycelial.technology>"]
 description = "Utilities for recognising and converting Secure Scuttlebutt (SSB) URIs"
 edition = "2018"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ readme = "README.md"
 repository = "https://github.com/ssb-ngi-pointer/ssb-uri-rs"
 
 [dependencies]
-anyhow = "1.0.44"
 percent-encoding = "2.1.0"
 regex = "1.5"
 url = "2.2.2"

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,8 @@
+use core::str::Utf8Error;
+use regex::Error as RegexError;
+use std::{error, fmt};
+use url::ParseError;
+
 #[derive(Debug)]
 pub enum SsbUriError {
     UnknownFormat(String),
@@ -9,8 +14,10 @@ pub enum SsbUriError {
     InvalidRegex(regex::Error),
 }
 
-impl std::fmt::Display for SsbUriError {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+impl error::Error for SsbUriError {}
+
+impl fmt::Display for SsbUriError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             SsbUriError::InvalidSuffix(ref err) => {
                 write!(f, "{}", err)
@@ -37,20 +44,20 @@ impl std::fmt::Display for SsbUriError {
     }
 }
 
-impl From<url::ParseError> for SsbUriError {
-    fn from(err: url::ParseError) -> SsbUriError {
+impl From<ParseError> for SsbUriError {
+    fn from(err: ParseError) -> SsbUriError {
         SsbUriError::ParseUrl(err)
     }
 }
 
-impl From<core::str::Utf8Error> for SsbUriError {
-    fn from(err: core::str::Utf8Error) -> SsbUriError {
+impl From<Utf8Error> for SsbUriError {
+    fn from(err: Utf8Error) -> SsbUriError {
         SsbUriError::InvalidUtf8(err)
     }
 }
 
-impl From<regex::Error> for SsbUriError {
-    fn from(err: regex::Error) -> SsbUriError {
+impl From<RegexError> for SsbUriError {
+    fn from(err: RegexError) -> SsbUriError {
         SsbUriError::InvalidRegex(err)
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -13,25 +13,25 @@ impl std::fmt::Display for SsbUriError {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match *self {
             SsbUriError::InvalidSuffix(ref err) => {
-                write!(f, "Sigil error: {}", err)
+                write!(f, "{}", err)
             }
             SsbUriError::InvalidUri(ref err) => {
-                write!(f, "URI error: {}", err)
+                write!(f, "{}", err)
             }
             SsbUriError::UnknownFormat(ref err) => {
-                write!(f, "Format error: {}", err)
+                write!(f, "{}", err)
             }
             SsbUriError::UnknownType(ref err) => {
-                write!(f, "Type error: {}", err)
+                write!(f, "{}", err)
             }
             SsbUriError::ParseUrl(ref err) => {
-                write!(f, "Parse error: {}", err)
+                write!(f, "{}", err)
             }
             SsbUriError::InvalidUtf8(ref err) => {
-                write!(f, "Decode error: {}", err)
+                write!(f, "{}", err)
             }
             SsbUriError::InvalidRegex(ref err) => {
-                write!(f, "Regex error: {}", err)
+                write!(f, "{}", err)
             }
         }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,6 +3,9 @@ use regex::Error as RegexError;
 use std::{error, fmt};
 use url::ParseError;
 
+/// A custom error type encapsulating all possible errors for this library.
+/// `From` implementations are provided for external error types, allowing
+/// the `?` operator to be used on functions which return `Result<_, SsbUriError>`.
 #[derive(Debug)]
 pub enum SsbUriError {
     UnknownFormat(String),

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,56 @@
+#[derive(Debug)]
+pub enum SsbUriError {
+    UnknownFormat(String),
+    UnknownType(String),
+    InvalidSuffix(String),
+    InvalidUri(String),
+    ParseUrl(url::ParseError),
+    InvalidUtf8(core::str::Utf8Error),
+    InvalidRegex(regex::Error),
+}
+
+impl std::fmt::Display for SsbUriError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match *self {
+            SsbUriError::InvalidSuffix(ref err) => {
+                write!(f, "Sigil error: {}", err)
+            }
+            SsbUriError::InvalidUri(ref err) => {
+                write!(f, "URI error: {}", err)
+            }
+            SsbUriError::UnknownFormat(ref err) => {
+                write!(f, "Format error: {}", err)
+            }
+            SsbUriError::UnknownType(ref err) => {
+                write!(f, "Type error: {}", err)
+            }
+            SsbUriError::ParseUrl(ref err) => {
+                write!(f, "Parse error: {}", err)
+            }
+            SsbUriError::InvalidUtf8(ref err) => {
+                write!(f, "Decode error: {}", err)
+            }
+            SsbUriError::InvalidRegex(ref err) => {
+                write!(f, "Regex error: {}", err)
+            }
+        }
+    }
+}
+
+impl From<url::ParseError> for SsbUriError {
+    fn from(err: url::ParseError) -> SsbUriError {
+        SsbUriError::ParseUrl(err)
+    }
+}
+
+impl From<core::str::Utf8Error> for SsbUriError {
+    fn from(err: core::str::Utf8Error) -> SsbUriError {
+        SsbUriError::InvalidUtf8(err)
+    }
+}
+
+impl From<regex::Error> for SsbUriError {
+    fn from(err: regex::Error) -> SsbUriError {
+        SsbUriError::InvalidRegex(err)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,10 +11,10 @@
 //! ## Example
 //!
 //!```
-//! use anyhow::Result;
 //! use ssb_uri_rs;
+//! use ssb_uri_rs::error::SsbUriError;
 //!
-//! fn example() -> Result<()> {
+//! fn example() -> Result<(), SsbUriError> {
 //!     let example_uri = "ssb:message/sha256/g3hPVPDEO1Aj_uPl0-J2NlhFB2bbFLIHlty-YuqFZ3w=";
 //!
 //!     assert!(ssb_uri_rs::is_classic_msg_uri(example_uri)?);
@@ -46,7 +46,7 @@
 //! ## License
 //!
 //! LGPL-3.0.
-mod error;
+pub mod error;
 
 use percent_encoding::{percent_decode, utf8_percent_encode, AsciiSet, NON_ALPHANUMERIC};
 use regex::Regex;


### PR DESCRIPTION
This PR removes the [`anyhow`](https://crates.io/crates/anyhow) crate dependency (which provides a trait object based error type) and replaces it with a handwritten, custom error type: `SsbUriError`.

I've been reading about Rust bloat and the factors which influence binary size and compilation time. During my reading, I learned that trait-based error handling libraries - while easy to use - often result in significantly slower compile times. Since ssb-uri-rs is a foundational library, it seems wise to trade a small amount of code complexity for improved compilation times.

**[ before ]**

19 total dependencies

debug compilation   : Finished dev [unoptimized + debuginfo] target(s) in 6.00s
release compilation : Finished release [optimized] target(s) in 8.39s

**[ after ]**

16 total dependencies

debug compilation   : Finished dev [unoptimized + debuginfo] target(s) in 3.42s
release compilation : Finished release [optimized] target(s) in 5.56s

-----

Here's [an article response](https://www.reddit.com/r/rust/comments/gj8inf/rust_structuring_and_handling_errors_in_2020/fqlmknt/) by burntsushi, briefly discussing the benefits of handwritten error impls.